### PR TITLE
Add pbc_shortest_vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsToolbox"
 uuid = "f386ec8f-7408-45ea-aa1c-e80969af901e"
 authors = ["Rashid Rafeek <rashidrafeek@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/AtomsToolbox.jl
+++ b/src/AtomsToolbox.jl
@@ -18,7 +18,7 @@ using AtomsBase: AtomsBase,
 using Unitful: Unitful, ustrip, @u_str, unit
 import Graphs
 using LinearAlgebra: LinearAlgebra, ⋅, det, norm, lu, ×
-using StaticArrays: StaticMatrix, Size
+using StaticArrays: StaticMatrix, SVector, Size
 import Base: angle, sort # To extend for AbstractSystem 
 
 # Some type piracy to deal with other packages

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -10,6 +10,6 @@ function Base.inv(x::StaticMatrix{N,M,T}) where {N,M,T <: Unitful.AbstractQuanti
 end 
 
 # These were removed in the AtomsBase 0.4 update
-Base.position(sys::AbstractSystem) = position.(sys, :)
+Base.position(sys::AbstractSystem) = position.(Ref(sys), 1:length(sys))
 AtomsBase.atomic_symbol(sys::AbstractSystem) = atomic_symbol.(species(sys, :))
 AtomsBase.atomic_number(sys::AbstractSystem) = atomic_number.(species(sys, :))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 AtomsIO = "1692102d-eeb4-4df9-807b-c9517f998d44"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"


### PR DESCRIPTION
Add `pbc_shortest_vector` function for finding shortest vector between two points, add tests.

 Update version to 0.1.3